### PR TITLE
[FEATURE/BUGFIX] Introduce ignoreFlexFormSettingsIfEmpty extbase configuration (backport from v12)

### DIFF
--- a/typo3/sysext/felogin/Configuration/TypoScript/setup.typoscript
+++ b/typo3/sysext/felogin/Configuration/TypoScript/setup.typoscript
@@ -5,6 +5,18 @@ plugin.tx_felogin_login {
     layoutRootPaths.10 = {$plugin.tx_felogin_login.view.layoutRootPath}
   }
 
+  ignoreFlexFormSettingsIfEmpty = showForgotPassword
+  ignoreFlexFormSettingsIfEmpty := addToList(showPermaLogin)
+  ignoreFlexFormSettingsIfEmpty := addToList(showLogoutFormAfterLogin)
+  ignoreFlexFormSettingsIfEmpty := addToList(pages)
+  ignoreFlexFormSettingsIfEmpty := addToList(recursive)
+  ignoreFlexFormSettingsIfEmpty := addToList(redirectMode)
+  ignoreFlexFormSettingsIfEmpty := addToList(redirectFirstMethod)
+  ignoreFlexFormSettingsIfEmpty := addToList(redirectPageLogin)
+  ignoreFlexFormSettingsIfEmpty := addToList(redirectPageLoginError)
+  ignoreFlexFormSettingsIfEmpty := addToList(redirectPageLogout)
+  ignoreFlexFormSettingsIfEmpty := addToList(redirectDisable)
+
   settings {
     pages = {$styles.content.loginform.pid}
     recursive = {$styles.content.loginform.recursive}


### PR DESCRIPTION
Backport the feature "ignoreFlexFormSettingsIfEmpty" along with the new default felogin settings to fix the bug in v11 related to typoscript settings not being able to configure any felogin settings (due to being overridden by flexform).

See:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/77885

Fixes this bug:
https://forge.typo3.org/issues/92363

Only the new setting is being backported, not the newly introduced "Signal", since we do not need it.