### PR TITLE
[BUGFIX] Editors should be allowed to delete files attached to meta data (backport to v11)

### DIFF
--- a/typo3/sysext/backend/Classes/Form/Container/InlineRecordContainer.php
+++ b/typo3/sysext/backend/Classes/Form/Container/InlineRecordContainer.php
@@ -469,8 +469,15 @@ class InlineRecordContainer extends AbstractContainer
         if ($isPagesTable) {
             $localCalcPerms = new Permission($backendUser->calcPerms(BackendUtility::getRecord('pages', $rec['uid'])));
         }
+        // Exception to the edit rules, allow editing of sys_file_reference records if the user has edit permissions
+        $isWriteableSysFileReferenceInSysFileTable = false;
+        if ($rec['table_local'] === 'sys_file' && $rec ['pid'] === 0) {
+            if ($backendUser->check('tables_modify', 'sys_file_metadata')) {
+                $isWriteableSysFileReferenceInSysFileTable = true;
+            }
+        }
         // This expresses the edit permissions for this particular element:
-        $permsEdit = ($isPagesTable && $localCalcPerms->editPagePermissionIsGranted()) || (!$isPagesTable && $calcPerms->editContentPermissionIsGranted());
+        $permsEdit = ($isPagesTable && $localCalcPerms->editPagePermissionIsGranted()) || (!$isPagesTable && ($calcPerms->editContentPermissionIsGranted() || $isWriteableSysFileReferenceInSysFileTable));
         // Controls: Defines which controls should be shown
         $enabledControls = $inlineConfig['appearance']['enabledControls'];
         // Hook: Can disable/enable single controls for specific child records:
@@ -586,15 +593,6 @@ class InlineRecordContainer extends AbstractContainer
             }
 
             // "Delete" link:
-
-            // Use the same security checks like above used to check the access to edit the file
-            $isWriteableSysFileReferenceInSysFileTable = false;
-            if ($rec['table_local'] === 'sys_file' && $rec ['pid'] === 0) {
-                if ($backendUser->check('tables_modify', 'sys_file_metadata')) {
-                    $isWriteableSysFileReferenceInSysFileTable = true;
-                }
-            }
-
             if ($enabledControls['delete'] && (($isPagesTable && $localCalcPerms->deletePagePermissionIsGranted())
                     || (!$isPagesTable && $calcPerms->editContentPermissionIsGranted())
                     || ($isSysFileReferenceTable  && (

--- a/typo3/sysext/backend/Classes/Form/Container/InlineRecordContainer.php
+++ b/typo3/sysext/backend/Classes/Form/Container/InlineRecordContainer.php
@@ -584,10 +584,24 @@ class InlineRecordContainer extends AbstractContainer
                         </a>';
                 }
             }
+
             // "Delete" link:
+
+            // Use the same security checks like above used to check the access to edit the file
+            $isWriteableSysFileReferenceInSysFileTable = false;
+            if ($rec['table_local'] === 'sys_file' && $rec ['pid'] === 0) {
+                if ($backendUser->check('tables_modify', 'sys_file_metadata')) {
+                    $isWriteableSysFileReferenceInSysFileTable = true;
+                }
+            }
+
             if ($enabledControls['delete'] && (($isPagesTable && $localCalcPerms->deletePagePermissionIsGranted())
                     || (!$isPagesTable && $calcPerms->editContentPermissionIsGranted())
-                    || ($isSysFileReferenceTable && $calcPerms->editPagePermissionIsGranted()))
+                    || ($isSysFileReferenceTable  && (
+                        ($calcPerms->editPagePermissionIsGranted()))
+                        || $isWriteableSysFileReferenceInSysFileTable
+                    )
+                )
             ) {
                 $title = htmlspecialchars($languageService->sL('LLL:EXT:core/Resources/Private/Language/locallang_mod_web_list.xlf:delete'));
                 $icon = $this->iconFactory->getIcon('actions-edit-delete', Icon::SIZE_SMALL)->render();


### PR DESCRIPTION
Backport of https://review.typo3.org/c/Packages/TYPO3.CMS/+/85110 (v13) to TYPO3 v11.

Also adding the icons for "hide" and "sort.up" and "sort.down" which were also missing.